### PR TITLE
Fix typos in 5.3-Legend/../stacked-bars.js

### DIFF
--- a/chapter_05/5.3-Legend/end/js/stacked-bars.js
+++ b/chapter_05/5.3-Legend/end/js/stacked-bars.js
@@ -1,5 +1,5 @@
 const drawStackedBars = (data) => {
-  
+
 
   /*******************************/
   /*    Append the containers    */
@@ -50,10 +50,10 @@ const drawStackedBars = (data) => {
   /*******************************/
   /*    Append the rectangles    */
   /*******************************/
-  annotatedData.forEach(serie => {
+  annotatedData.forEach(series => {
     innerChart
       .selectAll(`.bar-${series.key}`)
-      .data(serie)
+      .data(series)
       .join("rect")
         .attr("class", d => `bar-${series.key}`)
         .attr("x", d => xScale(d.data.year))
@@ -80,5 +80,5 @@ const drawStackedBars = (data) => {
   innerChart
     .append("g")
       .call(leftAxis);
-  
+
 };

--- a/chapter_05/5.3-Legend/start/js/stacked-bars.js
+++ b/chapter_05/5.3-Legend/start/js/stacked-bars.js
@@ -1,5 +1,5 @@
 const drawStackedBars = (data) => {
-  
+
 
   /*******************************/
   /*    Append the containers    */
@@ -50,10 +50,10 @@ const drawStackedBars = (data) => {
   /*******************************/
   /*    Append the rectangles    */
   /*******************************/
-  annotatedData.forEach(serie => {
+  annotatedData.forEach(series => {
     innerChart
       .selectAll(`.bar-${series.key}`)
-      .data(serie)
+      .data(series)
       .join("rect")
         .attr("class", d => `bar-${series.key}`)
         .attr("x", d => xScale(d.data.year))
@@ -80,5 +80,5 @@ const drawStackedBars = (data) => {
   innerChart
     .append("g")
       .call(leftAxis);
-  
+
 };


### PR DESCRIPTION
Applying the fix previously applied to 5.2-Stack_layout (https://github.com/d3js-in-action-third-edition/code-files/pull/2 / 7f5ae701032e70038ebd6bef5b6c56d5908622a3) to 5.3-Legend